### PR TITLE
Add load env function to help with setup

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,3 +1,47 @@
 #!/usr/bin/env bash
 
-iex -S mix phx.server
+set -Eeuo pipefail
+
+BASE_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+cd "${BASE_DIR}/.." || exit 127
+
+# shellcheck source=../scripts/helpers.sh
+. scripts/helpers.sh
+# shellcheck source=../scripts/logging.sh
+. scripts/logging.sh
+# shellcheck source=../scripts/utils.sh
+. scripts/utils.sh
+
+PROGRAM=$(basename "${BASH_SOURCE[0]:-$0}")
+VERSION=0.5.3
+
+function display_help() {
+  cat <<EOF
+  $(help_title_section Usage)
+    ${PROGRAM} [options] <command>
+
+  $(help_title_section Commands)
+    start             Start development server [default command].
+
+  $(help_title_section Options)
+    -h --help         Show this screen.
+    -v --version      Show version.
+EOF
+}
+
+case ${1:-start} in
+  -h | --help)
+    display_help
+    ;;
+  -v | --version)
+    display_version "${VERSION}" "${PROGRAM}"
+    ;;
+  start)
+      load_env_file
+      iex -S mix phx.server
+    ;;
+  *)
+    display_help >&2
+    exit 1
+    ;;
+esac

--- a/bin/test
+++ b/bin/test
@@ -1,6 +1,50 @@
 #!/usr/bin/env bash
 
-MIX_ENV=test mix ecto.reset
-mix test
-MIX_ENV=test mix test.run.newman
+set -Eeuo pipefail
+
+BASE_DIR=$(dirname "${BASH_SOURCE[0]:-$0}")
+cd "${BASE_DIR}/.." || exit 127
+
+# shellcheck source=../scripts/helpers.sh
+. scripts/helpers.sh
+# shellcheck source=../scripts/logging.sh
+. scripts/logging.sh
+# shellcheck source=../scripts/utils.sh
+. scripts/utils.sh
+
+PROGRAM=$(basename "${BASH_SOURCE[0]:-$0}")
+VERSION=0.5.3
+
+function display_help() {
+  cat <<EOF
+  $(help_title_section Usage)
+    ${PROGRAM} [options] <command>
+
+  $(help_title_section Commands)
+    all               Run all tests in test environment.
+
+  $(help_title_section Options)
+    -h --help         Show this screen.
+    -v --version      Show version.
+EOF
+}
+
+case ${1:-all} in
+  -h | --help)
+    display_help
+    ;;
+  -v | --version)
+    display_version "${VERSION}" "${PROGRAM}"
+    ;;
+  all)
+      load_env_file
+      MIX_ENV=test mix ecto.reset
+      mix test
+      MIX_ENV=test mix test.run.newman
+    ;;
+  *)
+    display_help >&2
+    exit 1
+    ;;
+esac
 

--- a/scripts/extras.sh
+++ b/scripts/extras.sh
@@ -133,4 +133,4 @@ function execute() {
   return $exitCode
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.0 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.3 || true

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -114,13 +114,19 @@ function format() {
     echo -en "\\033[0;${TYPE:-0}m"
   fi
 
-  if [[ ${#TEXT[@]} -gt 0 ]]; then
+  if [[ ${#TEXT[@]} -gt 1 ]]; then
     for text in "${TEXT[@]}"; do
       echo "$text"
+    done
+
+    echo -en '\033[0;0m'
+  elif [[ ${#TEXT[@]} -eq 1 ]]; then
+    for text in "${TEXT[@]}"; do
+      echo -n "$text"
     done
 
     echo -en '\033[0;0m'
   fi
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.0 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.3 || true

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -31,4 +31,4 @@ function help_title_section() {
   echo -e "${BOLD}${TITLE}${RESET}"
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.0 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.3 || true

--- a/scripts/logging.sh
+++ b/scripts/logging.sh
@@ -22,7 +22,7 @@ function __log() {
   [[ $(tput cols) -ge 80 ]] && SIZE=80 || SIZE=$(tput cols)
 
   # Get symbols from https://coolsymbol.com/
-  printf "_${COLOR}${BOLD}${LABEL}${RESET}_╞%*s\n" $(($SIZE - ${#LABEL} - 3)) " " | sed -e 's/ /═/g' | sed -e 's/_/ /g'
+  printf "_${COLOR}${BOLD}${LABEL}${RESET}_╞%*s\n" $((SIZE - ${#LABEL} - 3)) " " | sed -e 's/ /═/g' | sed -e 's/_/ /g'
   for M in "${MSG[@]}"; do
     echo "• $M"
   done
@@ -52,4 +52,4 @@ function log_info() {
   __log "${LABEL}" "$CYAN" "$@"
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.0 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.3 || true

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -16,6 +16,18 @@ function not_installed() {
   [ ! -x "$(command -v "$@")" ]
 }
 
+function load_env_file() {
+    local file="${1:-.env}"
+    if [ -f "$file" ]; then
+        log_info "Loading ${file} file..."
+        set -o allexport
+        source "$file"
+        set +o allexport
+    else
+        log_warn "${file} file not found, skipping..."
+    fi
+}
+
 function ask_for_sudo() {
   # Ask for the administrator password upfront.
   sudo -v &>/dev/null
@@ -40,4 +52,4 @@ function ensure_confirmation() {
   fi
 }
 
-[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.0 || true
+[ "$0" = "${BASH_SOURCE[0]}" ] && display_version 0.5.3 || true


### PR DESCRIPTION
This is a complimentary improve on the main development scripts based on the errors found by @miguelbrandao on setup based on a mistake fixed on  PR #13. 

This makes sure the `.env` file is loaded even if you don't have [direnv](https://direnv.net) installed, which you probably should anyway. 