### PR TITLE
Upgrade Erlang/OTP to release 24

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.3.2
+erlang 24.0
 elixir 1.11.4

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ local machine for development and testing purposes.
 
 The following software is required to be installed on your system:
 
-- [Erlang 23+](https://www.erlang.org/downloads)
+- [Erlang 24+](https://www.erlang.org/downloads)
 - [Elixir 1.11+](https://elixir-lang.org/install.html)
 - [PostgreSQL 13+](https://www.postgresql.org/download/)
 


### PR DESCRIPTION
Really quick testing on my machine (`mix compile`):

| **Erlang/OTP** |                    `time` |
| -------------: | ------------------------: |
|             23 | 145,78s user 6,26s system |
|             24 | 106,80s user 5,91s system |

Read more about this release:

- https://www.erlang.org/news/148
- https://blog.erlang.org/My-OTP-24-Highlights/