### PR TITLE
Change badges id to UUID and create a common app Schema

### DIFF
--- a/.postman/collection.json
+++ b/.postman/collection.json
@@ -1778,7 +1778,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"badge_id\": 2\n}",
+									"raw": "{\n    \"badge_id\": \"{{badge_id}}\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/lib/bokken/accounts/guardian.ex
+++ b/lib/bokken/accounts/guardian.ex
@@ -2,10 +2,8 @@ defmodule Bokken.Accounts.Guardian do
   @moduledoc """
   A guardian is the ninja's legal responsible.
   """
-  use Ecto.Schema
+  use Bokken.Schema
   use Waffle.Ecto.Schema
-
-  import Ecto.Changeset
 
   alias Bokken.Accounts.{Ninja, User}
   alias Bokken.Uploaders.Avatar
@@ -16,8 +14,6 @@ defmodule Bokken.Accounts.Guardian do
   @optional_fields [:city]
   @attachment_fields [:photo]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "guardians" do
     field :photo, Avatar.Type
     field :first_name, :string

--- a/lib/bokken/accounts/mentor.ex
+++ b/lib/bokken/accounts/mentor.ex
@@ -2,10 +2,8 @@ defmodule Bokken.Accounts.Mentor do
   @moduledoc """
   A mentor is a user who helps ninjas to progress in their training.
   """
-  use Ecto.Schema
+  use Bokken.Schema
   use Waffle.Ecto.Schema
-
-  import Ecto.Changeset
 
   alias Bokken.Accounts.{Organizer, Social, User}
   alias Bokken.Events.{Lecture, LectureMentorAssistant, Team, TeamMentor}
@@ -15,8 +13,6 @@ defmodule Bokken.Accounts.Mentor do
   @optional_fields [:birthday, :major]
   @attachment_fields [:photo]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "mentors" do
     field :photo, Avatar.Type
     field :first_name, :string

--- a/lib/bokken/accounts/ninja.ex
+++ b/lib/bokken/accounts/ninja.ex
@@ -2,10 +2,8 @@ defmodule Bokken.Accounts.Ninja do
   @moduledoc """
   A ninja is a dojo participant who is doing his training to learn and master programming.
   """
-  use Ecto.Schema
+  use Bokken.Schema
   use Waffle.Ecto.Schema
-
-  import Ecto.Changeset
 
   alias Bokken.Accounts.{Guardian, Social, User}
   alias Bokken.Events.{Lecture, Team, TeamNinja}
@@ -16,8 +14,6 @@ defmodule Bokken.Accounts.Ninja do
   @optional_fields [:notes, :user_id]
   @attachment_fields [:photo]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "ninjas" do
     field :photo, Avatar.Type
     field :first_name, :string

--- a/lib/bokken/accounts/organizer.ex
+++ b/lib/bokken/accounts/organizer.ex
@@ -2,15 +2,13 @@ defmodule Bokken.Accounts.Organizer do
   @moduledoc """
   An organizer is a person who arranges the details of an event.
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.{Mentor, User}
 
   @required_fields [:champion, :user_id]
   @optional_fields [:mentor_id]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "organizers" do
     field :champion, :boolean, default: false
 

--- a/lib/bokken/accounts/social.ex
+++ b/lib/bokken/accounts/social.ex
@@ -2,9 +2,9 @@ defmodule Bokken.Accounts.Social do
   @moduledoc """
   A social media embedded struct schema.
   """
-  use Ecto.Schema
-  import Ecto.Changeset
-  alias Bokken.Accounts.Social
+  use Bokken.Schema
+
+  alias __MODULE__
 
   @required_fields [:name, :username]
   @optional_fields []

--- a/lib/bokken/accounts/user.ex
+++ b/lib/bokken/accounts/user.ex
@@ -2,15 +2,13 @@ defmodule Bokken.Accounts.User do
   @moduledoc """
   A user of the application capable of authenticating.
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.{Guardian, Mentor, Ninja, Organizer}
 
   @required_fields [:email, :password, :role]
   @optional_fields [:active, :verified]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "users" do
     field :email, :string
     field :password_hash, :string

--- a/lib/bokken/events/event.ex
+++ b/lib/bokken/events/event.ex
@@ -2,16 +2,13 @@ defmodule Bokken.Events.Event do
   @moduledoc """
   An event of CoderDojo
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
 
   alias Bokken.Events.{Lecture, Location, Team}
 
   @required_fields [:team_id, :location_id, :online, :start_time, :end_time]
   @optional_fields [:notes, :title]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "events" do
     field :notes, :string
     field :online, :boolean

--- a/lib/bokken/events/lecture.ex
+++ b/lib/bokken/events/lecture.ex
@@ -2,16 +2,14 @@ defmodule Bokken.Events.Lecture do
   @moduledoc """
   one on one lecture
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.{Mentor, Ninja}
   alias Bokken.Events.{Event, LectureMentorAssistant}
 
   @required_fields [:ninja_id, :mentor_id, :event_id]
   @optional_fields [:notes, :summary, :attendance]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "lectures" do
     field :notes, :string
     field :summary, :string

--- a/lib/bokken/events/lecture_mentor_assistant.ex
+++ b/lib/bokken/events/lecture_mentor_assistant.ex
@@ -2,8 +2,8 @@ defmodule Bokken.Events.LectureMentorAssistant do
   @moduledoc """
   Lecture and Mentor Assistant join table
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.Mentor
   alias Bokken.Events.Lecture
 

--- a/lib/bokken/events/location.ex
+++ b/lib/bokken/events/location.ex
@@ -2,16 +2,13 @@ defmodule Bokken.Events.Location do
   @moduledoc """
   Location of an event
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
 
   alias Bokken.Events.Event
 
   @required_fields [:address, :name]
   @optional_fields []
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "locations" do
     field :address, :string
     field :name, :string

--- a/lib/bokken/events/team.ex
+++ b/lib/bokken/events/team.ex
@@ -2,16 +2,14 @@ defmodule Bokken.Events.Team do
   @moduledoc """
   A team is a working group formed by ninjas and mentors.
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.{Mentor, Ninja}
   alias Bokken.Events.{Event, TeamMentor, TeamNinja}
 
   @required_fields [:name]
   @optional_fields [:description]
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "teams" do
     field :description, :string
     field :name, :string

--- a/lib/bokken/events/team_mentor.ex
+++ b/lib/bokken/events/team_mentor.ex
@@ -2,8 +2,8 @@ defmodule Bokken.Events.TeamMentor do
   @moduledoc """
   Team and Mentor join table
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.Mentor
   alias Bokken.Events.Team
 

--- a/lib/bokken/events/team_ninja.ex
+++ b/lib/bokken/events/team_ninja.ex
@@ -2,8 +2,8 @@ defmodule Bokken.Events.TeamNinja do
   @moduledoc """
   Team and Ninja join table
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.Ninja
   alias Bokken.Events.Team
 

--- a/lib/bokken/gamification.ex
+++ b/lib/bokken/gamification.ex
@@ -68,19 +68,9 @@ defmodule Bokken.Gamification do
 
   """
   def create_badge(attrs \\ %{}) do
-    transaction =
-      Ecto.Multi.new()
-      |> Ecto.Multi.insert(:badge, Badge.changeset(%Badge{}, attrs))
-      |> Ecto.Multi.update(:badge_with_image, &Badge.image_changeset(&1.badge, attrs))
-      |> Repo.transaction()
-
-    case transaction do
-      {:ok, %{badge: badge, badge_with_image: badge_with_image}} ->
-        {:ok, %{badge | image: badge_with_image.image}}
-
-      {:error, _transation, errors, _changes_so_far} ->
-        {:error, errors}
-    end
+    %Badge{}
+    |> Badge.changeset(attrs)
+    |> Repo.insert()
   end
 
   @doc """
@@ -130,7 +120,6 @@ defmodule Bokken.Gamification do
   def change_badge(%Badge{} = badge, attrs \\ %{}) do
     badge
     |> Badge.changeset(attrs)
-    |> Badge.image_changeset(attrs)
   end
 
   alias Bokken.Gamification.BadgeNinja

--- a/lib/bokken/gamification/badge.ex
+++ b/lib/bokken/gamification/badge.ex
@@ -3,10 +3,8 @@ defmodule Bokken.Gamification.Badge do
   Badges are awards earned by ninjas for conquering challenges and finishing
   projects.
   """
-  use Ecto.Schema
+  use Bokken.Schema
   use Waffle.Ecto.Schema
-
-  import Ecto.Changeset
 
   alias Bokken.Accounts.Ninja
   alias Bokken.Gamification.BadgeNinja
@@ -27,15 +25,10 @@ defmodule Bokken.Gamification.Badge do
   end
 
   @doc false
-  def image_changeset(badge, attrs) do
-    badge
-    |> cast_attachments(attrs, @attachment_fields)
-  end
-
-  @doc false
   def changeset(badge, attrs) do
     badge
     |> cast(attrs, @required_fields ++ @optional_fields)
+    |> cast_attachments(attrs, @attachment_fields)
     |> validate_required(@required_fields)
   end
 end

--- a/lib/bokken/gamification/badge_ninja.ex
+++ b/lib/bokken/gamification/badge_ninja.ex
@@ -2,8 +2,8 @@ defmodule Bokken.Gamification.BadgeNinja do
   @moduledoc """
   Badge and Ninja join table
   """
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Bokken.Schema
+
   alias Bokken.Accounts.Ninja
   alias Bokken.Gamification.Badge
 
@@ -12,7 +12,7 @@ defmodule Bokken.Gamification.BadgeNinja do
 
   @primary_key false
   schema "badges_ninjas" do
-    belongs_to :badge, Badge
+    belongs_to :badge, Badge, type: :binary_id
     belongs_to :ninja, Ninja, type: :binary_id
 
     timestamps()

--- a/lib/bokken/schema.ex
+++ b/lib/bokken/schema.ex
@@ -1,0 +1,15 @@
+defmodule Bokken.Schema do
+  @moduledoc """
+  The application Schema for all the modules, providing Ecto.UUIDs as default
+  id.
+  """
+
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      import Ecto.Changeset
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+    end
+  end
+end

--- a/priv/repo/migrations/20210405161328_create_badges.exs
+++ b/priv/repo/migrations/20210405161328_create_badges.exs
@@ -2,7 +2,9 @@ defmodule Bokken.Repo.Migrations.CreateBadges do
   use Ecto.Migration
 
   def change do
-    create table(:badges) do
+    create table(:badges, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
       add :name, :string
       add :description, :string
       add :image, :string

--- a/priv/repo/migrations/20210406192208_create_badges_ninjas.exs
+++ b/priv/repo/migrations/20210406192208_create_badges_ninjas.exs
@@ -3,7 +3,7 @@ defmodule Bokken.Repo.Migrations.CreateBadgesNinjas do
 
   def change do
     create table(:badges_ninjas, primary_key: false) do
-      add :badge_id, references(:badges, on_delete: :nothing, type: :id), primary_key: true
+      add :badge_id, references(:badges, on_delete: :nothing, type: :binary_id), primary_key: true
       add :ninja_id, references(:ninjas, on_delete: :nothing, type: :binary_id), primary_key: true
 
       timestamps()


### PR DESCRIPTION
This allows to keep a common schema across all module schemas. Read more about [here](https://hexdocs.pm/ecto/Ecto.Schema.html#module-schema-attributes).
    
This also allows to not worry about the path of an image based on the ID because UUID are generating before inserting the data to the db. Read [this](https://hexdocs.pm/waffle_ecto/filepath-with-id.html) to understand why badge image does not require creation to be a transaction anymore.