### PR TITLE
Fix 500 on user verification

### DIFF
--- a/lib/bokken/accounts.ex
+++ b/lib/bokken/accounts.ex
@@ -667,7 +667,9 @@ defmodule Bokken.Accounts do
 
   """
   def verify_user_email(email) do
-    user = get_user(email: email)
+    user =
+      get_user(email: email)
+      |> Repo.preload([:guardian, :organizer, :mentor, :ninja])
 
     if is_nil(user) do
       {:error, :not_found}


### PR DESCRIPTION
The issue was the user type association (guardian, mentor, .etc) was not being loaded but the view expected it to be.

The fix was loading the association when the user is being verified