### PR TITLE
Fix bin/server script

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -37,6 +37,7 @@ case ${1:-start} in
     display_version "${VERSION}" "${PROGRAM}"
     ;;
   start)
+    load_env_file .env.dev
     mix phx.server
     ;;
   *)


### PR DESCRIPTION
Unfortunately, for now, the waffle library can't use the `runtime.exs`
to evaluate the HOST_URL, making it ignoring any dynamic loading of
environment variables.

This way, all variables from `.env` file are loaded in our shell.
