### PR TITLE
Add parameters in lecture index

### DIFF
--- a/lib/bokken/events.ex
+++ b/lib/bokken/events.ex
@@ -345,15 +345,30 @@ defmodule Bokken.Events do
 
   ## Examples
 
-      iex> list_lectures()
+      iex> list_lectures(%{"ninja_id" => 123})
       [%Lecture{}, ...]
 
   """
+  def list_lectures(params, preloads \\ [])
 
-  def list_lectures do
+  def list_lectures(%{"mentor_id" => mentor_id}, preloads) do
+    Lecture
+    |> where([l], l.mentor_id == ^mentor_id)
+    |> Repo.all()
+    |> Repo.preload(preloads)
+  end
+
+  def list_lectures(%{"ninja_id" => ninja_id}, preloads) do
+    Lecture
+    |> where([l], l.ninja_id == ^ninja_id)
+    |> Repo.all()
+    |> Repo.preload(preloads)
+  end
+
+  def list_lectures(_params, preloads) do
     Lecture
     |> Repo.all()
-    |> Repo.preload([:ninja, :event, :mentor, :assistant_mentors, :files])
+    |> Repo.preload(preloads)
   end
 
   @doc """

--- a/lib/bokken_web/controllers/lecture_controller.ex
+++ b/lib/bokken_web/controllers/lecture_controller.ex
@@ -6,8 +6,8 @@ defmodule BokkenWeb.LectureController do
 
   action_fallback BokkenWeb.FallbackController
 
-  def index(conn, _params) do
-    lectures = Events.list_lectures()
+  def index(conn, params) do
+    lectures = Events.list_lectures(params, [:ninja, :event, :mentor, :assistant_mentors, :files])
     render(conn, "index.json", lectures: lectures)
   end
 
@@ -30,7 +30,7 @@ defmodule BokkenWeb.LectureController do
   end
 
   def show(conn, %{"id" => id}) do
-    lecture = Events.get_lecture!(id)
+    lecture = Events.get_lecture!(id, [:event, :mentor, :ninja])
     render(conn, "show.json", lecture: lecture)
   end
 


### PR DESCRIPTION
Allow a parameterized index search for lectures. This will allow the frontend to only receive lectures of the ninja / mentor it needs. This will be especially useful considering the number of lectures will increase really quickly with time.