### PR TITLE
Update availability and ninja views

### DIFF
--- a/lib/bokken_web/views/availability_view.ex
+++ b/lib/bokken_web/views/availability_view.ex
@@ -19,7 +19,7 @@ defmodule BokkenWeb.AvailabilityView do
 
   def render("availability.json", %{availability: availability}) do
     %{
-      id: availability.id,
+      availability_id: availability.id,
       is_available: availability.is_available,
       notes: availability.notes
     }

--- a/lib/bokken_web/views/ninja_view.ex
+++ b/lib/bokken_web/views/ninja_view.ex
@@ -21,7 +21,8 @@ defmodule BokkenWeb.NinjaView do
       belt: ninja.belt,
       notes: ninja.notes,
       socials: ninja.socials,
-      since: ninja.inserted_at
+      since: ninja.inserted_at,
+      guardian_id: ninja.guardian_id
     }
     |> Map.merge(skills(ninja))
   end

--- a/test/bokken_web/controllers/availability_controller_test.exs
+++ b/test/bokken_web/controllers/availability_controller_test.exs
@@ -61,7 +61,7 @@ defmodule BokkenWeb.AvailabilityControllerTest do
           valid_availability_attrs
         )
 
-      assert %{"id" => availability_id} = json_response(conn, 201)["data"]
+      assert %{"availability_id" => availability_id} = json_response(conn, 201)["data"]
 
       conn = get(conn, Routes.event_availability_path(conn, :show, event.id, availability_id))
       assert json_response(conn, 200)["data"]


### PR DESCRIPTION
I need this for [#62](https://github.com/coderdojobraga/shuriken/pull/62).
I changed `id` to `availability_id` because it was being replaced by the user's `id` - conflicting names.