### PR TITLE
Fix events tests

### DIFF
--- a/test/bokken/events_test.exs
+++ b/test/bokken/events_test.exs
@@ -1,6 +1,8 @@
 defmodule Bokken.EventsTest do
   use Bokken.DataCase
 
+  import Bokken.Factory
+
   alias Bokken.Accounts
   alias Bokken.Events
   alias Bokken.Repo
@@ -9,19 +11,6 @@ defmodule Bokken.EventsTest do
     def valid_enrollment do
       %{
         accepted: false
-      }
-    end
-
-    def valid_event do
-      %{
-        title: "Test event",
-        spots_available: 30,
-        start_time: ~U[2023-02-14 10:00:00.000Z],
-        end_time: ~U[2023-02-14 12:30:00.000Z],
-        enrollments_open: ~U[2022-07-03 12:30:00.0Z],
-        enrollments_close: ~U[2023-02-13 12:30:00.0Z],
-        online: false,
-        notes: "Valentines"
       }
     end
 
@@ -93,7 +82,7 @@ defmodule Bokken.EventsTest do
       {:ok, new_team} = Events.create_team(valid_team())
 
       event =
-        valid_event()
+        params_for(:event)
         |> Map.put(:location_id, new_location.id)
         |> Map.put(:team_id, new_team.id)
 
@@ -246,16 +235,7 @@ defmodule Bokken.EventsTest do
         |> Events.create_team()
 
       event =
-        %{
-          title: "Test event",
-          spots_available: 30,
-          start_time: ~U[2023-02-14 10:00:00.000Z],
-          end_time: ~U[2023-02-14 12:30:00.000Z],
-          enrollments_open: ~U[2022-07-03 12:30:00.0Z],
-          enrollments_close: ~U[2023-02-13 12:30:00.0Z],
-          online: false,
-          notes: "Valentines"
-        }
+        params_for(:event)
         |> Map.put(:location_id, new_location.id)
         |> Map.put(:team_id, new_team.id)
 

--- a/test/bokken_web/controllers/availability_controller_test.exs
+++ b/test/bokken_web/controllers/availability_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule BokkenWeb.AvailabilityControllerTest do
   use BokkenWeb.ConnCase
 
+  import Bokken.Factory
+
   alias Bokken.Events
 
   setup %{conn: conn} do
@@ -19,16 +21,7 @@ defmodule BokkenWeb.AvailabilityControllerTest do
       |> Events.create_team()
 
     event_fixture =
-      %{
-        title: "Test event",
-        spots_available: 30,
-        start_time: ~U[2023-02-14 10:00:00.000Z],
-        end_time: ~U[2023-02-14 12:30:00.000Z],
-        enrollments_open: ~U[2022-07-03 12:30:00.0Z],
-        enrollments_close: ~U[2023-02-13 12:30:00.0Z],
-        online: false,
-        notes: "Valentines"
-      }
+      params_for(:event)
       |> Map.put(:location_id, location.id)
       |> Map.put(:team_id, team.id)
 

--- a/test/bokken_web/controllers/enrollment_controller_test.exs
+++ b/test/bokken_web/controllers/enrollment_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule BokkenWeb.EnrollmentControllerTest do
   use BokkenWeb.ConnCase
 
+  import Bokken.Factory
+
   alias Bokken.Accounts
   alias Bokken.Events
   alias BokkenWeb.Authorization
@@ -94,17 +96,6 @@ defmodule BokkenWeb.EnrollmentControllerTest do
       description: "Uma turma"
     }
 
-    event_attrs = %{
-      title: "Test event",
-      spots_available: 30,
-      start_time: ~U[2023-02-14 10:00:00.000Z],
-      end_time: ~U[2023-02-14 12:30:00.000Z],
-      enrollments_open: ~U[2022-07-03 12:30:00.0Z],
-      enrollments_close: ~U[2023-02-13 12:30:00.0Z],
-      online: false,
-      notes: "Valentines"
-    }
-
     new_user_ninja = Accounts.create_user(user_ninja)
 
     ninja_fixture =
@@ -119,7 +110,7 @@ defmodule BokkenWeb.EnrollmentControllerTest do
     {:ok, team} = Events.create_team(team_attrs)
 
     event_fixture =
-      event_attrs
+      params_for(:event)
       |> Map.put(:location_id, location.id)
       |> Map.put(:team_id, team.id)
 


### PR DESCRIPTION
Basically, we were using hardcoded enrollments' dates and that was resulting on closed enrollments/availabilities errors.
Now the tests are using `ex-machina`.