### PR TITLE
feat: add spots available in the event reminder

### DIFF
--- a/lib/bokken_web/templates/email/guardian_event_reminder.html.eex
+++ b/lib/bokken_web/templates/email/guardian_event_reminder.html.eex
@@ -24,7 +24,8 @@
                       <ul style="Margin-top: 16px;Margin-bottom: 20px; text-align:center; list-style: none; padding: 0;">
                         <li>📅 <%= display_date(@event.start_time) %> </li>
                         <li>⏱ <%= display_time(@event.start_time) %> - <%= display_time(@event.end_time) %></li>
-                        <li>⌖ <%= @event.location.address %><li>
+                        <li>⌖ <%= @event.location.address %></li>
+                        <li>⚠️ Limite de inscrições: <%= @event.spots_available %></li>
                       </h1>
                     </div>
                   </div>


### PR DESCRIPTION
This PR intends to solve the #218 issue. It adds a line to the email responsible for reminding the guardians about a new upcoming event.

![image](https://github.com/coderdojobraga/bokken/assets/109802203/8f586dc8-a349-4efa-aac8-ee5f51c17e77)
